### PR TITLE
Makes post data available

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -455,9 +455,9 @@ impl<State, Error> Api<State, Error> {
     ///
     /// type State = RwLock<u64>;
     ///
-    /// # fn ex(api: &mut Api<State, ()>) {
+    /// # fn ex(api: &mut Api<State, tide_disco::RequestError>) {
     /// api.post("replace", |req, state| async move {
-    ///     *state = req.u64_param("new_state").unwrap();
+    ///     *state = req.u64_param("new_state")?;
     ///     Ok(())
     /// }.boxed());
     /// # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ use tide::{
     http::headers::HeaderValue,
     http::mime,
     security::{CorsMiddleware, Origin},
-    Request, Response, StatusCode,
+    Request, Response,
 };
 use toml::value::Value;
 use tracing::error;
@@ -176,8 +176,8 @@ pub mod route;
 pub use api::Api;
 pub use app::App;
 pub use error::Error;
-pub use request::RequestParams;
-pub use tide::http;
+pub use request::{RequestError, RequestParam, RequestParamType, RequestParamValue, RequestParams};
+pub use tide::http::{self, StatusCode};
 
 #[derive(AsRefStr, Debug)]
 #[allow(non_camel_case_types)]

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,12 +1,33 @@
 use snafu::{OptionExt, Snafu};
 use std::collections::HashMap;
+use std::fmt::Display;
 use strum_macros::EnumString;
 use tagged_base64::TaggedBase64;
 use tide::http::Headers;
 
 #[derive(Clone, Debug, Snafu)]
 pub enum RequestError {
-    MissingParam { param: RequestParam },
+    #[snafu(display("missing required parameter: {}", name))]
+    MissingParam { name: String },
+
+    #[snafu(display(
+        "incorrect type for parameter {}: {} cannot be converted to {}",
+        name,
+        param_type,
+        expected
+    ))]
+    IncorrectParamType {
+        name: String,
+        param_type: RequestParamType,
+        expected: String,
+    },
+
+    #[snafu(display("value {} for {} is too large for type {}", value, name, expected))]
+    IntegerOverflow {
+        value: u128,
+        name: String,
+        expected: String,
+    },
 }
 
 /// Parameters passed to a route handler.
@@ -44,23 +65,168 @@ impl RequestParams {
     }
 
     /// Get the value of a named parameter.
-    pub fn param(&self, name: &str) -> Option<&RequestParamValue> {
-        self.params.get(name)
+    ///
+    /// The name of the parameter can be given by any type that implements [Display]. Of course, the
+    /// simplest option is to use [str] or [String], as in
+    ///
+    /// ```
+    /// # use tide_disco::*;
+    /// # fn ex(req: &RequestParams) {
+    /// req.param("foo")
+    /// # ;}
+    /// ```
+    ///
+    /// However, you have the option of defining a statically typed enum representing the possible
+    /// parameters of a given route and using enum variants as parameter names. Among other
+    /// benefits, this allows you to change the client-facing parameter names just by tweaking the
+    /// [Display] implementation of your enum, without changing other code.
+    ///
+    /// ```
+    /// use std::fmt::{self, Display, Formatter};
+    ///
+    /// enum RouteParams {
+    ///     Param1,
+    ///     Param2,
+    /// }
+    ///
+    /// impl Display for RouteParams {
+    ///     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+    ///         let name = match self {
+    ///             Self::Param1 => "param1",
+    ///             Self::Param2 => "param2",
+    ///         };
+    ///         write!(f, "{}", name)
+    ///     }
+    /// }
+    ///
+    /// # use tide_disco::*;
+    /// # fn ex(req: &RequestParams) {
+    /// req.param(&RouteParams::Param1)
+    /// # ;}
+    /// ```
+    ///
+    /// You can also use [strum_macros] to automatically derive the [Display] implementation, so you
+    /// only have to specify the client-facing names of each parameter:
+    ///
+    /// ```
+    /// #[derive(strum_macros::Display)]
+    /// enum RouteParams {
+    ///     #[strum(serialize = "param1")]
+    ///     Param1,
+    ///     #[strum(serialize = "param2")]
+    ///     Param2,
+    /// }
+    ///
+    /// # use tide_disco::*;
+    /// # fn ex(req: &RequestParams) {
+    /// req.param(&RouteParams::Param1)
+    /// # ;}
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// Returns [RequestError::MissingParam] if a parameter called `name` was not provided with the
+    /// request.
+    ///
+    /// It is recommended to implement `From<RequestError>` for the error type for your API, so that
+    /// you can use `?` with this function in a route handler. If your error type implements
+    /// [Error](crate::Error), you can easily use the [catch_all](crate::Error::catch_all)
+    /// constructor to do this:
+    ///
+    /// ```
+    /// use serde::{Deserialize, Serialize};
+    /// use snafu::Snafu;
+    /// use tide_disco::{Error, RequestError, RequestParams, StatusCode};
+    ///
+    /// type ApiState = ();
+    ///
+    /// #[derive(Debug, Snafu, Deserialize, Serialize)]
+    /// struct ApiError {
+    ///     status: StatusCode,
+    ///     msg: String,
+    /// }
+    ///
+    /// impl Error for ApiError {
+    ///     fn catch_all(status: StatusCode, msg: String) -> Self {
+    ///         Self { status, msg }
+    ///     }
+    ///
+    ///     fn status(&self) -> StatusCode {
+    ///         self.status
+    ///     }
+    /// }
+    ///
+    /// impl From<RequestError> for ApiError {
+    ///     fn from(err: RequestError) -> Self {
+    ///         Self::catch_all(StatusCode::BadRequest, err.to_string())
+    ///     }
+    /// }
+    ///
+    /// async fn my_route_handler(req: RequestParams, _state: &ApiState) -> Result<(), ApiError> {
+    ///     let param = req.param("my_param")?;
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn param<Name>(&self, name: &Name) -> Result<&RequestParamValue, RequestError>
+    where
+        Name: ?Sized + Display,
+    {
+        self.params
+            .get(&name.to_string())
+            .context(MissingParamSnafu {
+                name: name.to_string(),
+            })
     }
 
     /// Get the value of a named parameter and convert it to an integer.
-    pub fn integer_param(&self, name: &str) -> Option<u128> {
-        self.params.get(name).and_then(|val| val.as_integer())
+    ///
+    /// Like [param](Self::param), but returns [None] if the parameter value cannot be converted to
+    /// an integer.
+    pub fn integer_param<Name>(&self, name: &Name) -> Result<u128, RequestError>
+    where
+        Name: ?Sized + Display,
+    {
+        self.param(name).and_then(|val| {
+            val.as_integer().context(IncorrectParamTypeSnafu {
+                name: name.to_string(),
+                param_type: val.param_type(),
+                expected: "Integer".to_string(),
+            })
+        })
     }
 
     /// Get the value of a named parameter and convert it to a [u64].
-    pub fn u64_param(&self, name: &str) -> Option<u64> {
-        self.integer_param(name).and_then(|i| i.try_into().ok())
+    ///
+    /// Like [param](Self::param), but returns [None] if the parameter value cannot be converted to
+    /// a [u64].
+    pub fn u64_param<Name>(&self, name: &Name) -> Result<u64, RequestError>
+    where
+        Name: ?Sized + Display,
+    {
+        self.integer_param(name).and_then(|i| {
+            i.try_into().ok().context(IntegerOverflowSnafu {
+                name: name.to_string(),
+                value: i,
+                expected: "u64".to_string(),
+            })
+        })
     }
 
     /// Get the value of a named parameter and convert it to a string.
-    pub fn string_param(&self, name: &str) -> Option<String> {
-        self.params.get(name).and_then(|val| val.as_string())
+    ///
+    /// Like [param](Self::param), but returns [None] if the parameter value cannot be converted to
+    /// a [String].
+    pub fn string_param<Name>(&self, name: &Name) -> Result<String, RequestError>
+    where
+        Name: ?Sized + Display,
+    {
+        self.param(name).and_then(|val| {
+            val.as_string().context(IncorrectParamTypeSnafu {
+                name: name.to_string(),
+                param_type: val.param_type(),
+                expected: "String".to_string(),
+            })
+        })
     }
 
     pub fn body_bytes(&self) -> Vec<u8> {
@@ -101,6 +267,16 @@ impl RequestParamValue {
         }
     }
 
+    pub fn param_type(&self) -> RequestParamType {
+        match self {
+            Self::Boolean(_) => RequestParamType::Boolean,
+            Self::Hexadecimal(_) => RequestParamType::Hexadecimal,
+            Self::Integer(_) => RequestParamType::Integer,
+            Self::TaggedBase64(_) => RequestParamType::TaggedBase64,
+            Self::Literal(_) => RequestParamType::Literal,
+        }
+    }
+
     pub fn as_string(&self) -> Option<String> {
         match self {
             Self::Literal(s) => Some(s.clone()),
@@ -115,7 +291,7 @@ impl RequestParamValue {
     }
 }
 
-#[derive(Clone, Copy, Debug, EnumString)]
+#[derive(Clone, Copy, Debug, EnumString, strum_macros::Display)]
 pub enum RequestParamType {
     Boolean,
     Hexadecimal,


### PR DESCRIPTION
The RequestParams struct now supplies post data via `fn body_bytes()`.

Thanks to Jeb for helping me navigate the type constraints and asynchronous design. There was a poor design choice in a library Tide uses that has an astonishing definition of `clone()` that drops the useful data.