### PR TITLE
Set up Nix development

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,5 @@
+use nix
+watch_file flake.nix
+watch_file shell.nix
+watch_file flake.lock
+watch_file .envrc

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,150 @@
+{
+  "nodes": {
+    "fenix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "rust-analyzer-src": "rust-analyzer-src"
+      },
+      "locked": {
+        "lastModified": 1660112944,
+        "narHash": "sha256-6oRTsYGJXjFbcWz3H/1TJDbu2cYoXnYwK8NKfMQNuXU=",
+        "owner": "nix-community",
+        "repo": "fenix",
+        "rev": "b952fad30060fb7a98613b30e3b4df0d160e492c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "fenix",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1656928814,
+        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1659981942,
+        "narHash": "sha256-uCFiP/B/NXOWzhN6TKfMbSxtVMk1bVnCrnJRjCF6RmU=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "39d7f929fbcb1446ad7aa7441b04fb30625a4190",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1659102345,
+        "narHash": "sha256-Vbzlz254EMZvn28BhpN8JOi5EuKqnHZ3ujFYgFcSGvk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "11b60e4f80d87794a2a4a8a256391b37c59a1ea7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "fenix": "fenix",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-analyzer-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1660078984,
+        "narHash": "sha256-EOazwimkZv9fCQ2IwUnUwpykYj7XiILiO7OBzT20xR0=",
+        "owner": "rust-lang",
+        "repo": "rust-analyzer",
+        "rev": "5366009fe47ab06e53b68811873448de52c5cd8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rust-lang",
+        "ref": "nightly",
+        "repo": "rust-analyzer",
+        "type": "github"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1660125530,
+        "narHash": "sha256-iGeuTN/uts+1Qy+M9ZUPkuoxewwWCZ5kyPh9sA8OsqQ=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "9391a9f23da71d0c61117caba5b0f1debb69bcbd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,91 @@
+# Copyright (c) 2022 Espresso Systems (espressosys.com)
+# This file is part of the Tide Disco library.
+#
+# This program is free software: you can redistribute it and/or modify it under the terms of the GNU
+# General Public License as published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+# This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without
+# even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+# You should have received a copy of the GNU General Public License along with this program. If not,
+# see <https://www.gnu.org/licenses/>.
+
+{
+  description = "Development shell for Tide Disco";
+
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  inputs.flake-compat.url = "github:edolstra/flake-compat";
+  inputs.flake-compat.flake = false;
+
+  inputs.rust-overlay.url = "github:oxalica/rust-overlay";
+
+  inputs.fenix.url = "github:nix-community/fenix";
+  inputs.fenix.inputs.nixpkgs.follows = "nixpkgs";
+
+  outputs = { self, nixpkgs, flake-utils, flake-compat, rust-overlay, fenix, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        info = builtins.split "\([a-zA-Z0-9_]+\)" system;
+        arch = (builtins.elemAt (builtins.elemAt info 1) 0);
+        os = (builtins.elemAt (builtins.elemAt info 3) 0);
+        overlays = [ (import rust-overlay) ];
+        pkgs = import nixpkgs { inherit system overlays; };
+        rustToolchain = pkgs.rust-bin.stable.latest.minimal.override {
+          extensions = [ "rustfmt" "clippy" "llvm-tools-preview" "rust-src" ];
+        };
+        rustDeps = with pkgs;
+          [
+            pkgconfig
+            openssl
+            bash
+
+            curl
+
+            cargo-edit
+            cargo-udeps
+            cargo-sort
+            cmake
+          ] ++ lib.optionals stdenv.isDarwin [
+            darwin.apple_sdk.frameworks.Security
+            darwin.apple_sdk.frameworks.CoreFoundation
+            darwin.apple_sdk.frameworks.SystemConfiguration
+
+            # https://github.com/NixOS/nixpkgs/issues/126182
+            libiconv
+          ] ++ lib.optionals (stdenv.system != "aarch64-darwin") [
+            cargo-watch # broken: https://github.com/NixOS/nixpkgs/issues/146349
+          ];
+        # nixWithFlakes allows pre v2.4 nix installations to use
+        # flake commands (like `nix flake update`)
+        nixWithFlakes = pkgs.writeShellScriptBin "nix" ''
+          exec ${pkgs.nixFlakes}/bin/nix --experimental-features "nix-command flakes" "$@"
+        '';
+        shellHook  = ''
+          # on mac os `bin/pwd -P` returns the canonical path on case insensitive file-systems
+          my_pwd=$(/bin/pwd -P 2> /dev/null || pwd)
+
+          export PATH=${pkgs.xdot}/bin:$PATH
+          export PATH=''${my_pwd}/bin:$PATH
+        '';
+      in {
+        devShell = pkgs.mkShell {
+          shellHook = shellHook;
+          buildInputs = with pkgs;
+            [
+              fenix.packages.${system}.rust-analyzer
+              nixWithFlakes
+              nixpkgs-fmt
+              git
+              mdbook # make-doc, documentation generation
+              rustToolchain
+            ] ++ rustDeps;
+
+          RUST_SRC_PATH = "${rustToolchain}/lib/rustlib/src/rust/library";
+          RUST_BACKTRACE = 1;
+          RUST_LOG = "info";
+        };
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,13 @@
+(import
+  (
+    let
+      lock = builtins.fromJSON (builtins.readFile ./flake.lock);
+    in
+    fetchTarball {
+      url = "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
+      sha256 = lock.nodes.flake-compat.locked.narHash;
+    }
+  )
+  {
+    src = ./.;
+  }).shellNix


### PR DESCRIPTION
Convenient for switching between projects when I'm using other Nix
for other projects.

To be clear, this should always remain optional: we should continue
to support non-Nix development.