### PR TITLE
Fix Windows build

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -17,6 +17,10 @@ on:
     branches:
       - main
       - release-*
+  pull_request:
+    branches:
+      - main
+      - release-*
   workflow_dispatch:
 
 jobs:

--- a/src/app.rs
+++ b/src/app.rs
@@ -595,8 +595,8 @@ mod test {
             .unwrap();
         }
         let port = pick_unused_port().unwrap();
-        let url: Url = format!("http://0.0.0.0:{}", port).parse().unwrap();
-        spawn(app.serve(url.to_string()));
+        let url: Url = format!("http://localhost:{}", port).parse().unwrap();
+        spawn(app.serve(format!("0.0.0.0:{}", port)));
         wait_for_server(&url, SERVER_STARTUP_RETRIES, SERVER_STARTUP_SLEEP_MS).await;
 
         let client: surf::Client = surf::Config::new()


### PR DESCRIPTION
* On Windows, 0.0.0.0 does not automatically resolve to localhost,
  so we need to bind to 0.0.0.0 but connect to `localhost`.
* Socket closure is handled differently on Windows
* Run Windows build on PRs. It is quick, and likely to frequently
  break `main` if we don't run it, since we are not typically
  developing on Windows and a lot of the domain of this repo has
  platform-dependent semantics