### PR TITLE
Support optional parameters.

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -430,7 +430,7 @@ impl RequestParamValue {
         if let Ok(param) = req.param(&formal.name) {
             Self::parse(param, formal).map(Some)
         } else {
-            unimplemented!("check for the parameter in the request body")
+            Ok(None)
         }
     }
 
@@ -553,7 +553,6 @@ pub enum RequestParamType {
 pub struct RequestParam {
     pub name: String,
     pub param_type: RequestParamType,
-    pub required: bool,
 }
 
 pub(crate) fn best_response_type(
@@ -613,7 +612,6 @@ mod test {
             &RequestParam {
                 name: name.to_string(),
                 param_type: ty,
-                required: true,
             },
         )
         .unwrap()


### PR DESCRIPTION
* Removes a panic in request parsing when a formal parameter from
  another route pattern is not specified
* Fixes some redundancy in route spec parsing
* Removes `RequestParam::required`, as it is not used and not really
  meaningful (a parameter is required relative to a particular route
  pattern, but a route can have many patterns, and Tide already
  ensures that all the parameters for a given pattern are present
  before dispatching to that pattern)
* Adds a new test

Closes #37