### PR TITLE
Support prometheus endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,6 +1946,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "quote"
 version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +2874,7 @@ dependencies = [
  "maud",
  "parking_lot",
  "portpicker",
+ "prometheus",
  "routefinder",
  "semver 1.0.18",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ libc = "0.2.151"
 markdown = "0.3"
 maud = { version = "0.25", features = ["tide"] }
 parking_lot = "0.12.0"
+prometheus = "0.13"
 routefinder = "0.5.0"
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -269,6 +269,7 @@ pub mod app;
 pub mod error;
 pub mod healthcheck;
 pub mod method;
+pub mod metrics;
 pub mod request;
 pub mod route;
 pub mod socket;

--- a/src/method.rs
+++ b/src/method.rs
@@ -30,6 +30,7 @@ use std::str::FromStr;
 pub enum Method {
     Http(http::Method),
     Socket,
+    Metrics,
 }
 
 impl Method {
@@ -58,6 +59,11 @@ impl Method {
         Self::Socket
     }
 
+    /// The Tide Disco METRICS method.
+    pub fn metrics() -> Self {
+        Self::Metrics
+    }
+
     /// Check if a method is a standard HTTP method.
     pub fn is_http(&self) -> bool {
         matches!(self, Self::Http(_))
@@ -68,6 +74,7 @@ impl Method {
         match self {
             Self::Http(m) => !m.is_safe(),
             Self::Socket => true,
+            Self::Metrics => false,
         }
     }
 }
@@ -83,6 +90,7 @@ impl Display for Method {
         match self {
             Self::Http(m) => write!(f, "{}", m),
             Self::Socket => write!(f, "SOCKET"),
+            Self::Metrics => write!(f, "METRICS"),
         }
     }
 }
@@ -93,10 +101,10 @@ impl FromStr for Method {
     type Err = ParseMethodError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if s == "SOCKET" {
-            Ok(Self::Socket)
-        } else {
-            s.parse().map_err(|_| ParseMethodError).map(Self::Http)
+        match s {
+            "SOCKET" => Ok(Self::Socket),
+            "METRICS" => Ok(Self::Metrics),
+            _ => s.parse().map_err(|_| ParseMethodError).map(Self::Http),
         }
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,0 +1,83 @@
+// Copyright (c) 2022 Espresso Systems (espressosys.com)
+// This file is part of the tide-disco library.
+
+// You should have received a copy of the MIT License
+// along with the tide-disco library. If not, see <https://mit-license.org/>.
+
+//! Support for routes using the Prometheus metrics format.
+
+use crate::{
+    method::ReadState,
+    request::RequestParams,
+    route::{self, RouteError},
+};
+use async_trait::async_trait;
+use derive_more::From;
+use futures::future::{BoxFuture, FutureExt};
+use prometheus::{Encoder, TextEncoder};
+use std::{borrow::Cow, error::Error, fmt::Debug};
+
+pub trait Metrics {
+    type Error: Debug + Error;
+
+    fn export(&self) -> Result<String, Self::Error>;
+}
+
+impl Metrics for prometheus::Registry {
+    type Error = prometheus::Error;
+
+    fn export(&self) -> Result<String, Self::Error> {
+        let mut buffer = vec![];
+        let encoder = TextEncoder::new();
+        let metric_families = self.gather();
+        encoder.encode(&metric_families, &mut buffer)?;
+        String::from_utf8(buffer).map_err(|err| {
+            prometheus::Error::Msg(format!(
+                "could not convert Prometheus output to UTF-8: {err}",
+            ))
+        })
+    }
+}
+
+/// A [Handler](route::Handler) which delegates to an async function returning metrics.
+///
+/// The function type `F` should be callable as
+/// `async fn(RequestParams, &State) -> Result<&R, Error>`. The [Handler] implementation will
+/// automatically convert the result `R` to a [tide::Response] by exporting the [Metrics] to text,
+/// or the error `Error` to a [RouteError] using [RouteError::AppSpecific].
+///
+/// # Limitations
+///
+/// [Like many function parameters](crate#boxed-futures) in [tide_disco](crate), the handler
+/// function is required to return a [BoxFuture].
+#[derive(From)]
+pub(crate) struct Handler<F>(F);
+
+#[async_trait]
+impl<F, T, State, Error> route::Handler<State, Error> for Handler<F>
+where
+    F: 'static + Send + Sync + Fn(RequestParams, &State::State) -> BoxFuture<Result<Cow<T>, Error>>,
+    T: 'static + Clone + Metrics,
+    State: 'static + Send + Sync + ReadState,
+    Error: 'static,
+{
+    async fn handle(
+        &self,
+        req: RequestParams,
+        state: &State,
+    ) -> Result<tide::Response, RouteError<Error>> {
+        let exported = state
+            .read(|state| {
+                let fut = (self.0)(req, state);
+                async move {
+                    let metrics = fut.await.map_err(RouteError::AppSpecific)?;
+                    metrics
+                        .export()
+                        .map_err(|err| RouteError::ExportMetrics(err.to_string()))
+                }
+                .boxed()
+            })
+            .await?;
+        Ok(exported.into())
+    }
+}

--- a/src/request.rs
+++ b/src/request.rs
@@ -584,14 +584,19 @@ pub(crate) fn best_response_type(
         } else if proposed.subtype() == "*" {
             // If the subtype is * but the basetype is not, look for a proposed type with a matching
             // basetype and any subtype.
-            for mime in available {
-                if mime.basetype() == proposed.basetype() {
-                    return Ok(mime.clone());
-                }
+            if let Some(mime) = available
+                .iter()
+                .find(|mime| mime.basetype() == proposed.basetype())
+            {
+                return Ok(mime.clone());
             }
-        } else if available.contains(proposed) {
+        } else {
             // If neither part of the proposal is a wildcard, look for a literal match.
-            return Ok((**proposed).clone());
+            if let Some(mime) = available.iter().find(|mime| {
+                mime.basetype() == proposed.basetype() && mime.subtype() == proposed.subtype()
+            }) {
+                return Ok(mime.clone());
+            }
         }
     }
 


### PR DESCRIPTION
We add a new pseudo-method METRICS, similar to how we dispatch SOCKET requests as if there were a SOCKET HTTP method. A request is considered to have the METRICS method if its actual method is GET and its preferred content type is text/plain. This is backwards compatible since all existing endpoints return either application/json or application/octet-stream.

A new middleware is installed on endpoints that have a METRICS handler. It intercepts GET requests that are actually METRICS requests and routes them to the corresponding METRICS handler.

Closes #70