### PR TITLE
Runtime binding for app-level format version

### DIFF
--- a/examples/hello-world/main.rs
+++ b/examples/hello-world/main.rs
@@ -11,7 +11,7 @@ use snafu::Snafu;
 use std::io;
 use tide_disco::{Api, App, Error, RequestError, StatusCode};
 use tracing::info;
-use vbs::version::StaticVersion;
+use vbs::version::{StaticVersion, StaticVersionType};
 
 type StaticVer01 = StaticVersion<0, 1>;
 
@@ -42,7 +42,7 @@ impl From<RequestError> for HelloError {
 }
 
 async fn serve(port: u16) -> io::Result<()> {
-    let mut app = App::<_, HelloError, StaticVer01>::with_state(RwLock::new("Hello".to_string()));
+    let mut app = App::<_, HelloError>::with_state(RwLock::new("Hello".to_string()));
     app.with_version(env!("CARGO_PKG_VERSION").parse().unwrap());
 
     let mut api =
@@ -78,7 +78,8 @@ async fn serve(port: u16) -> io::Result<()> {
     .unwrap();
 
     app.register_module("hello", api).unwrap();
-    app.serve(format!("0.0.0.0:{}", port)).await
+    app.serve(format!("0.0.0.0:{}", port), StaticVer01::instance())
+        .await
 }
 
 #[async_std::main]

--- a/examples/versions/main.rs
+++ b/examples/versions/main.rs
@@ -7,12 +7,12 @@
 use futures::FutureExt;
 use std::io;
 use tide_disco::{error::ServerError, Api, App};
-use vbs::version::StaticVersion;
+use vbs::version::{StaticVersion, StaticVersionType};
 
 type StaticVer01 = StaticVersion<0, 1>;
 
 async fn serve(port: u16) -> io::Result<()> {
-    let mut app = App::<_, ServerError, StaticVer01>::with_state(());
+    let mut app = App::<_, ServerError>::with_state(());
     app.with_version(env!("CARGO_PKG_VERSION").parse().unwrap());
 
     let mut v1 =
@@ -31,7 +31,8 @@ async fn serve(port: u16) -> io::Result<()> {
         .unwrap()
         .register_module("api", v2)
         .unwrap();
-    app.serve(format!("0.0.0.0:{}", port)).await
+    app.serve(format!("0.0.0.0:{}", port), StaticVer01::instance())
+        .await
 }
 
 #[async_std::main]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,13 +100,13 @@
 //! # let spec: toml::Value = toml::from_str(std::str::from_utf8(&std::fs::read("/path/to/api.toml").unwrap()).unwrap()).unwrap();
 //! # let api = tide_disco::Api::<State, Error, StaticVer01>::new(spec).unwrap();
 //! use tide_disco::App;
-//! use vbs::version::StaticVersion;
+//! use vbs::version::{StaticVersion, StaticVersionType};
 //!
 //! type StaticVer01 = StaticVersion<0, 1>;
 //!
-//! let mut app = App::<State, Error, StaticVer01>::with_state(());
+//! let mut app = App::<State, Error>::with_state(());
 //! app.register_module("api", api);
-//! app.serve("http://localhost:8080").await;
+//! app.serve("http://localhost:8080", StaticVer01::instance()).await;
 //! # }
 //! ```
 //!

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -113,16 +113,15 @@ impl MetricsMiddleware {
     }
 }
 
-impl<State, Error, VER> tide::Middleware<Arc<App<State, Error, VER>>> for MetricsMiddleware
+impl<State, Error> tide::Middleware<Arc<App<State, Error>>> for MetricsMiddleware
 where
     State: Send + Sync + 'static,
     Error: crate::Error + Send + Sync + 'static,
-    VER: StaticVersionType + Send + Sync + 'static,
 {
     fn handle<'a, 'b, 't>(
         &'a self,
-        req: tide::Request<Arc<App<State, Error, VER>>>,
-        next: tide::Next<'b, Arc<App<State, Error, VER>>>,
+        req: tide::Request<Arc<App<State, Error>>>,
+        next: tide::Next<'b, Arc<App<State, Error>>>,
     ) -> BoxFuture<'t, tide::Result>
     where
         'a: 't,
@@ -165,8 +164,8 @@ where
     }
 }
 
-pub(crate) async fn request_params<State, Error: crate::Error, VER: StaticVersionType>(
-    req: tide::Request<Arc<App<State, Error, VER>>>,
+pub(crate) async fn request_params<State, Error: crate::Error>(
+    req: tide::Request<Arc<App<State, Error>>>,
     params: &[RequestParam],
 ) -> Result<RequestParams, tide::Error> {
     RequestParams::new(req, params)


### PR DESCRIPTION
The App format version is no longer required to be consistent with anything else (APIs all have their own versions), so we don't need it to be a static parameter of the whole `App`. We can move it to just a parameter of `serve`, which simplifies the interface a bit.

Also found, fixed, and added a test for a bug where we were using the app version to serialize the response for API-level version endpoints, rather than the API version.