### PR TITLE
Allow socket messages to/from clients to be handled in separate tasks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3462,7 +3462,7 @@ dependencies = [
 
 [[package]]
 name = "tide-disco"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "ark-serialize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3489,6 +3489,7 @@ dependencies = [
  "markdown",
  "maud",
  "parking_lot",
+ "pin-project",
  "portpicker",
  "prometheus",
  "reqwest",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ libc = "0.2"
 markdown = "0.3"
 maud = { version = "0.26", features = ["tide"] }
 parking_lot = "0.12"
+pin-project = "1.0"
 prometheus = "0.13"
 reqwest = { version = "0.12", features = ["json"] }
 routefinder = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tide-disco"
-version = "0.8.0"
+version = "0.9.0"
 edition = "2021"
 authors = ["Espresso Systems <hello@espressosys.com>"]
 description = "Discoverability for Tide"

--- a/flake.lock
+++ b/flake.lock
@@ -55,24 +55,6 @@
         "type": "github"
       }
     },
-    "flake-utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1705309234,
-        "narHash": "sha256-uNRRNRKmJyCRC/8y1RqBkqWBLM034y4qN7EprSdmgyA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "1ef2e671c3b0c19053962c07dbda38332dcebf26",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1711703276,
@@ -91,11 +73,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1706487304,
-        "narHash": "sha256-LE8lVX28MV2jWJsidW13D2qrHU/RUUONendL2Q/WlJg=",
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "90f456026d284c22b3e3497be980b2e47d0b28ac",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
         "type": "github"
       },
       "original": {
@@ -133,15 +115,14 @@
     },
     "rust-overlay": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1716949111,
-        "narHash": "sha256-ms3aD3Z2jKd1dk8qd0D/N7C8vFxn6z6LQ1G7cvNTVJ8=",
+        "lastModified": 1719886738,
+        "narHash": "sha256-6eaaoJUkr4g9J/rMC4jhj3Gv8Sa62rvlpjFe3xZaSjM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "2e7ccf572ce0f0547d4cf4426de4482936882d0e",
+        "rev": "db12d0c6ef002f16998723b5dd619fa7b8997086",
         "type": "github"
       },
       "original": {
@@ -151,21 +132,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/src/app.rs
+++ b/src/app.rs
@@ -956,7 +956,7 @@ mod test {
             .unwrap()
             .socket(
                 "socket_test",
-                |_req, mut conn: Connection<_, (), _, StaticVer01>, _state| {
+                |_req, mut conn: Connection<str, (), _, StaticVer01>, _state| {
                     async move {
                         conn.send("SOCKET").await.unwrap();
                         Ok(())

--- a/src/socket.rs
+++ b/src/socket.rs
@@ -20,6 +20,7 @@ use futures::{
     task::{Context, Poll},
     FutureExt, Sink, SinkExt, Stream, StreamExt, TryFutureExt,
 };
+use pin_project::pin_project;
 use serde::{de::DeserializeOwned, Serialize};
 use std::borrow::Cow;
 use std::fmt::{self, Display, Formatter};
@@ -133,7 +134,9 @@ enum MessageType {
 ///
 /// [Connection] implements [Stream], which can be used to receive `FromClient` messages from the
 /// client, and [Sink] which can be used to send `ToClient` messages to the client.
+#[pin_project]
 pub struct Connection<ToClient: ?Sized, FromClient, Error, VER: StaticVersionType> {
+    #[pin]
     conn: WebSocketConnection,
     // [Sink] wrapper around `conn`
     sink: Pin<Box<dyn Send + Sink<Message, Error = SocketError<Error>>>>,
@@ -150,7 +153,7 @@ impl<ToClient: ?Sized, FromClient: DeserializeOwned, E, VER: StaticVersionType> 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // Get a `Pin<&mut WebSocketConnection>` for the underlying connection, so we can use the
         // `Stream` implementation of that field.
-        match self.pinned_inner().poll_next(cx) {
+        match self.project().conn.poll_next(cx) {
             Poll::Ready(None) => Poll::Ready(None),
             Poll::Ready(Some(Err(err))) => Poll::Ready(Some(Err(err.into()))),
             Poll::Ready(Some(Ok(msg))) => Poll::Ready(Some(match msg {
@@ -216,32 +219,6 @@ impl<ToClient: Serialize, FromClient, E, VER: StaticVersionType> Sink<ToClient>
     }
 }
 
-impl<ToClient: ?Sized, FromClient, Error, VER: StaticVersionType> Drop
-    for Connection<ToClient, FromClient, Error, VER>
-{
-    fn drop(&mut self) {
-        // This is the idiomatic way to implement [drop] for a type that uses pinning. Since [drop]
-        // is implicitly called with `&mut self` even on types that were pinned, we place any
-        // implementation inside [inner_drop], which takes `Pin<&mut Self>`, when the commpiler will
-        // be able to check that we do not do anything that we couldn't have done on a
-        // `Pin<&mut Self>`.
-        //
-        // The [drop] implementation for this type is trivial, and it would be safe to use the
-        // automatically generated [drop] implementation, but we nonetheless implement [drop]
-        // explicitly in the idiomatic fashion so that it is impossible to accidentally implement an
-        // unsafe version of [drop] for this type in the future.
-
-        // `new_unchecked` is okay because we know this value is never used again after being
-        // dropped.
-        inner_drop(unsafe { Pin::new_unchecked(self) });
-        fn inner_drop<ToClient: ?Sized, FromClient, Error, VER: StaticVersionType>(
-            _this: Pin<&mut Connection<ToClient, FromClient, Error, VER>>,
-        ) {
-            // Any logic goes here.
-        }
-    }
-}
-
 impl<ToClient: ?Sized, FromClient, E, VER: StaticVersionType>
     Connection<ToClient, FromClient, E, VER>
 {
@@ -270,28 +247,6 @@ impl<ToClient: ?Sized, FromClient, E, VER: StaticVersionType>
             conn.send(msg).await?;
             Ok(conn)
         }))
-    }
-
-    /// Project a `Pin<&mut Self>` to a pinned reference to the underlying connection.
-    fn pinned_inner(self: Pin<&mut Self>) -> Pin<&mut WebSocketConnection> {
-        // # Soundness
-        //
-        // This implements _structural pinning_ for [Connection]. This comes with some requirements
-        // to maintain safety, as described at
-        // https://doc.rust-lang.org/std/pin/index.html#pinning-is-structural-for-field:
-        //
-        // 1. The struct must only be [Unpin] if all the structural fields are [Unpin]. This is the
-        //    default, and we don't explicitly implement [Unpin] for [Connection].
-        // 2. The destructor of the struct must not move structural fields out of its argument. This
-        //    is enforced by the compiler in our [Drop] implementation, which follows the idiom for
-        //    safe [Drop] implementations for pinned structs.
-        // 3. You must make sure that you uphold the [Drop] guarantee: once your struct is pinned,
-        //    the memory that contains the content is not overwritten or deallocated without calling
-        //    the content’s destructors. This is also enforced by our [Drop] implementation.
-        // 4. You must not offer any other operations that could lead to data being moved out of the
-        //    structural fields when your type is pinned. There are no operations on this type that
-        //    move out of `conn`.
-        unsafe { self.map_unchecked_mut(|s| &mut s.conn) }
     }
 }
 


### PR DESCRIPTION
This is a use case required by the node dashboard server.

### This PR:
* Adds a `Sink<ToClient>` impl for `Connection`, to complement the existing `Sink<&ToClient>` impl. This allows the user to avoid some lifetime issues that crop up when splitting the `Connection` into separate sink and source (see new documentation and commit messages for more details)
* Implements `Clone` for `Connection`, which allows the connection to be sent into two different tasks without being cloned, so that the by-reference `Sink<&ToClient>` impl can still be used
* Updates the Rust version in the Nix shell
* Cleans up `Connection` by removing some tricky manual pinning code that can be derived instead

### Key places to review:
* `Clone for Connection`
* `Sink<ToClient> for Connection`
* New documentation on `Api::socket`
