### PR TITLE
Remove serving of public directory

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -382,10 +382,6 @@ impl<State, Error> ApiInner<State, Error> {
         }
     }
 
-    pub(crate) fn public(&self) -> Option<&PathBuf> {
-        self.public.as_ref()
-    }
-
     pub(crate) fn set_name(&mut self, name: String) {
         self.name = name;
     }
@@ -552,12 +548,6 @@ where
     /// the API.
     pub fn with_version(&mut self, version: Version) -> &mut Self {
         self.inner.api_version = Some(version);
-        self
-    }
-
-    /// Serve the contents of `dir` at the URL `/public/{{NAME}}`.
-    pub fn with_public(&mut self, dir: PathBuf) -> &mut Self {
-        self.inner.public = Some(dir);
         self
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -599,6 +599,7 @@ pub fn compose_config_path(org_dir_name: &str, app_name: &str) -> PathBuf {
 /// - A configuration file from the app
 /// - Command line arguments
 /// - Environment variables
+///
 /// Last one wins.
 ///
 /// Environment variables have a prefix of the given app_name in upper case with hyphens converted


### PR DESCRIPTION
Removes the serving of a public directory. I checked and none of our code uses this right now

The only thing I want to be sure of is that `app.rs:400` does not break anything (the removal of `/public`). I tested locally and everything works, but wanted to make sure