### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3618,7 +3618,7 @@ dependencies = [
 
 [[package]]
 name = "tide-disco"
-version = "0.9.3"
+version = "0.9.4"
 dependencies = [
  "anyhow",
  "ark-serialize",


### PR DESCRIPTION
The crate publishing steps fails if the Cargo.lock file is out of date.